### PR TITLE
Fix: keep original jsoncore config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 .DS_Store
 .README.md.html
 settings.json
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr

--- a/src/main/java/com/github/wnameless/json/flattener/JsonFlattener.java
+++ b/src/main/java/com/github/wnameless/json/flattener/JsonFlattener.java
@@ -109,7 +109,7 @@ public final class JsonFlattener {
     return new JsonFlattener(json).flattenAsMap();
   }
 
-  private static final JsonCore<?> jsonCore = new JacksonJsonCore();
+  private final JsonCore<?> jsonCore;
   private final Deque<IndexedPeekIterator<?>> elementIters = new ArrayDeque<>();
   private final JsonValueBase<?> source;
 
@@ -125,7 +125,7 @@ public final class JsonFlattener {
   private boolean ignoreReservedCharacters = false;
 
   private JsonFlattener newJsonFlattener(JsonValueBase<?> jsonVal) {
-    JsonFlattener jf = new JsonFlattener(jsonVal);
+    JsonFlattener jf = new JsonFlattener(jsonCore, jsonVal);
     jf.withFlattenMode(flattenMode);
     jf.withStringEscapePolicy(policy);
     jf.withSeparator(separator);
@@ -142,8 +142,7 @@ public final class JsonFlattener {
    * @param json a {@link JsonValueBase}
    */
   public JsonFlattener(JsonValueBase<?> json) {
-    if (json == null) throw new NullPointerException();
-    source = json;
+    this(new JacksonJsonCore(), json);
   }
 
   /**
@@ -153,6 +152,8 @@ public final class JsonFlattener {
    * @param json a JSON string
    */
   public JsonFlattener(JsonCore<?> jsonCore, JsonValueBase<?> json) {
+    if (json == null) throw new NullPointerException();
+    this.jsonCore = jsonCore;
     source = jsonCore.parse(json.toJson());
   }
 
@@ -162,7 +163,7 @@ public final class JsonFlattener {
    * @param json a JSON string
    */
   public JsonFlattener(String json) {
-    source = jsonCore.parse(json);
+    this(new JacksonJsonCore(), json);
   }
 
   /**
@@ -172,6 +173,7 @@ public final class JsonFlattener {
    * @param json a JSON string
    */
   public JsonFlattener(JsonCore<?> jsonCore, String json) {
+    this.jsonCore = jsonCore;
     source = jsonCore.parse(json);
   }
 
@@ -182,7 +184,7 @@ public final class JsonFlattener {
    * @throws IOException if the jsonReader cannot be read
    */
   public JsonFlattener(Reader jsonReader) throws IOException {
-    source = jsonCore.parse(jsonReader);
+    this(new JacksonJsonCore(), jsonReader);
   }
 
   /**
@@ -193,6 +195,7 @@ public final class JsonFlattener {
    * @throws IOException if the jsonReader cannot be read
    */
   public JsonFlattener(JsonCore<?> jsonCore, Reader jsonReader) throws IOException {
+    this.jsonCore = jsonCore;
     source = jsonCore.parse(jsonReader);
   }
 

--- a/src/main/java/com/github/wnameless/json/unflattener/JsonUnflattener.java
+++ b/src/main/java/com/github/wnameless/json/unflattener/JsonUnflattener.java
@@ -111,7 +111,7 @@ public final class JsonUnflattener {
   private KeyTransformer keyTrans = null;
 
   private JsonUnflattener newJsonUnflattener(JsonValueCore<?> jsonValue) {
-    JsonUnflattener ju = new JsonUnflattener(jsonValue);
+    JsonUnflattener ju = new JsonUnflattener(jsonCore, jsonValue);
     ju.withFlattenMode(flattenMode);
     ju.withSeparator(separator);
     ju.withLeftAndRightBrackets(leftBracket, rightBracket);
@@ -120,8 +120,8 @@ public final class JsonUnflattener {
     return ju;
   }
 
-  private JsonUnflattener(JsonValueCore<?> root) {
-    jsonCore = new JacksonJsonCore();
+  private JsonUnflattener(JsonCore<?> jsonCore, JsonValueCore<?> root) {
+    this.jsonCore = jsonCore;
     this.root = root;
   }
 


### PR DESCRIPTION
This PR is to honor the initial configured JsonCore setting

I excluded the jackson libraries from the classpath and configured the JsonUnflattener to use the GsonJsonCore, but I got the next exception when using:
```
com/fasterxml/jackson/core/JsonProcessingException
java.lang.NoClassDefFoundError: com/fasterxml/jackson/core/JsonProcessingException
	at com.github.wnameless.json.unflattener.JsonUnflattener.<init>(JsonUnflattener.java:124)
	at com.github.wnameless.json.unflattener.JsonUnflattener.newJsonUnflattener(JsonUnflattener.java:114)
	at com.github.wnameless.json.unflattener.JsonUnflattener.setUnflattenedValue(JsonUnflattener.java:533)
	at com.github.wnameless.json.unflattener.JsonUnflattener.unflatten(JsonUnflattener.java:407)
```

